### PR TITLE
Fix the Catalyst dependency version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
   (eval { ExtUtils::MakeMaker->VERSION(6.31) } ? (LICENSE => 'perl') : ()),
   PREREQ_PM    => {
     "namespace::autoclean" => '0',
-    "Catalyst" => '5.800006',
+    "Catalyst" => '5.80006',
     "Carp::REPL" => '0',
   },
 );


### PR DESCRIPTION
The version of the Catalyst pre-requisite module has an extra 0 which causes some build tools to fail the test and don't find a version higher than the "required". I'm aware this is a read-only repo but it's the easiest way to submit the fix.
